### PR TITLE
prerm: Always exit 0 even if shutdown fails

### DIFF
--- a/debian/prerm
+++ b/debian/prerm
@@ -1,3 +1,4 @@
 #!/bin/bash
 
 stop drserv
+exit 0


### PR DESCRIPTION
Shutdown can fail if the drserv isn't running, which is fine and shouldn't abort
the uninstall procedure.
