### PR TITLE
Fix postinst script to handle disabled server

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -1,4 +1,13 @@
 #!/bin/bash
 
 adduser --system drserv
-start drserv
+
+DEFAULTFILE=/etc/default/drserv
+[ -f $DEFAULTFILE ] && . $DEFAULTFILE
+
+# Only start if explicitly enabled in config
+if [ "$ENABLED" == "yes" ] ; then
+  start drserv
+else
+  echo "drserv not enabled in $DEFAULTFILE, not starting"
+fi

--- a/debian/upstart
+++ b/debian/upstart
@@ -18,6 +18,7 @@ pre-start script
 
   # don't start unless explicitly enabled in config
   if [ "$ENABLED" != "yes" ] ; then
+    echo "NOTE: drserv not enabled in $DEFAULTFILE, not starting"
     stop; exit 0;
   fi
 end script


### PR DESCRIPTION
This change makes the postinst script source the /etc/default/drserv file and
not try to start the server unless it has been properly enabled.

Before this change the postinst script used to exit with an unhelpful error
message (and an exit code) when the server was disabled.
