### PR TITLE
Default to creating group writable files & dirs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+drserv (0.1.1) unstable; urgency=low
+
+  * debian/upstart:
+    - Update umask to 002. Creating group writable directories is good for
+      interacting with pre-drserv ways of uploading packages.
+
+ -- Client-Build <client-build@spotify.com>  Fri, 29 May 2015 17:38:15 +0000
+
 drserv (0.1.0) unstable; urgency=low
 
   * Initial release.

--- a/debian/upstart
+++ b/debian/upstart
@@ -10,6 +10,7 @@ respawn limit unlimited
 # Drop privileges
 setuid drserv
 setgid nogroup
+umask 002
 
 env DEFAULTFILE=/etc/default/drserv
 


### PR DESCRIPTION
This is good for being able to interact with any pre-drserv system that you
might have in place.
